### PR TITLE
fix(mortgage): recalculate payments based on remaining term months

### DIFF
--- a/src/lib/stores/gameState.ts
+++ b/src/lib/stores/gameState.ts
@@ -879,10 +879,17 @@ function calculateMortgageInterestRate(
 	return baseRate + depositPremium + btlPremium;
 }
 
+function calculateRemainingMonths(startDate: GameDate, termYears: number, currentDate: GameDate): number {
+	const totalMonths = termYears * 12;
+	const monthsElapsed = (currentDate.year - startDate.year) * 12 + 
+						 (currentDate.month - startDate.month);
+	return Math.max(1, totalMonths - monthsElapsed); // Minimum 1 month
+}
+
 function calculateMonthlyMortgagePayment(
 	loanAmount: number,
 	annualInterestRate: number,
-	termYears: TermLength,
+	termMonths: number,
 	mortgageType: MortgageType
 ): number {
 	if (mortgageType === 'btl') {
@@ -892,7 +899,7 @@ function calculateMonthlyMortgagePayment(
 	
 	// Standard mortgage: Calculate amortization payment
 	const monthlyRate = annualInterestRate / 100 / 12;
-	const numPayments = termYears * 12;
+	const numPayments = termMonths;
 	
 	// M = P * [r(1+r)^n] / [(1+r)^n - 1]
 	const payment = loanAmount * (monthlyRate * Math.pow(1 + monthlyRate, numPayments)) / 
@@ -1009,10 +1016,17 @@ function createGameStore() {
 						
 						// Only update if rate has changed
 						if (newRate !== mortgage.interestRate) {
+							// Calculate remaining months from start date
+							const remainingMonths = calculateRemainingMonths(
+								mortgage.startDate,
+								mortgage.termLengthYears,
+								newDate
+							);
+							
 							const newMonthlyPayment = calculateMonthlyMortgagePayment(
 								mortgage.outstandingBalance,
 								newRate,
-								mortgage.termLengthYears,
+								remainingMonths,
 								mortgage.mortgageType
 							);
 							
@@ -2152,7 +2166,7 @@ function createGameStore() {
 				const monthlyPayment = calculateMonthlyMortgagePayment(
 					loanAmount,
 					interestRate,
-					termLength,
+					termLength * 12,
 					mortgageType
 				);
 
@@ -2248,7 +2262,7 @@ function createGameStore() {
 				const monthlyPayment = calculateMonthlyMortgagePayment(
 					loanAmount,
 					interestRate,
-					termLength,
+					termLength * 12,
 					mortgageType
 				);
 


### PR DESCRIPTION
When variable rate mortgage interest rates change, payments are now recalculated using the remaining months instead of the original term length. This ensures accurate amortization as the mortgage ages.

Changes:
- Add calculateRemainingMonths() helper to compute remaining term
- Refactor calculateMonthlyMortgagePayment() to accept months instead of years
- Update variable rate logic to pass remaining months on rate changes
- Convert term years to months at initial mortgage creation callsites

This fixes incorrect payment amounts when interest rates adjust on mortgages that have already been partially paid down.